### PR TITLE
Clean up docker configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ plugins {
     id 'net.researchgate.release' version '2.7.0'
     id 'com.github.kt3k.coveralls' version '2.8.2'
     id 'org.sonarqube' version '2.6.2'
-    id 'com.palantir.docker' version '0.20.1'
-    id 'nebula.ospackage' version '5.0.2'
     id 'org.owasp.dependencycheck' version '3.3.2'
-    id 'org.ajoberstar.grgit' version '2.3.0'
+    id 'com.palantir.docker' version '0.20.1' apply false
+    id 'nebula.ospackage' version '5.0.2' apply false
+    id 'org.ajoberstar.grgit' version '2.3.0' apply false
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,10 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'net.researchgate.release' version '2.7.0'
     id 'com.github.kt3k.coveralls' version '2.8.2'
-    id 'org.sonarqube' version '2.6.2'
     id 'org.owasp.dependencycheck' version '3.3.2'
+    id 'org.sonarqube' version '2.6.2'
     id 'com.palantir.docker' version '0.20.1' apply false
     id 'nebula.ospackage' version '5.0.2' apply false
-    id 'org.ajoberstar.grgit' version '2.3.0' apply false
 }
 
 ext {

--- a/deployment/build.gradle
+++ b/deployment/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'application'
 apply plugin: 'distribution'
 apply plugin: 'com.palantir.docker'
 apply plugin: 'nebula.ospackage-application'
-apply plugin: 'org.ajoberstar.grgit'
 
 description = 'Trellis Database Application'
 mainClassName = 'org.trellisldp.ext.app.db.TrellisApplication'
@@ -71,8 +70,15 @@ docker {
     buildArgs([BUILD_VERSION: project.version])
     def gitLabels = ['git.url':'https://github.com/trellis-ldp/trellis-ext-db']
     try {
-        git = grgit.open()
-        gitLabels.put('git.commit', git.head().id);
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'rev-parse', '--short', 'HEAD'
+            standardOutput = stdout
+        }
+        def hash = stdout.toString('UTF-8')
+        if (!hash.isEmpty()) {
+            gitLabels.put('git.commit', hash)
+        }
     } catch (all) { }
     labels(gitLabels)
     pull false

--- a/deployment/build.gradle
+++ b/deployment/build.gradle
@@ -75,7 +75,7 @@ docker {
             commandLine 'git', 'rev-parse', '--short', 'HEAD'
             standardOutput = stdout
         }
-        def hash = stdout.toString('UTF-8')
+        def hash = stdout.toString('UTF-8').trim()
         if (!hash.isEmpty()) {
             gitLabels.put('git.commit', hash)
         }

--- a/deployment/build.gradle
+++ b/deployment/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'application'
 apply plugin: 'distribution'
+apply plugin: 'com.palantir.docker'
 apply plugin: 'nebula.ospackage-application'
+apply plugin: 'org.ajoberstar.grgit'
 
 description = 'Trellis Database Application'
 mainClassName = 'org.trellisldp.ext.app.db.TrellisApplication'
@@ -11,10 +13,6 @@ dependencies {
 
     runtime("javax.xml.bind:jaxb-api:$jaxbVersion")
 }
-
-// Get commit id of HEAD.
-apply plugin: 'java'
-apply plugin: 'application'
 
 ospackage {
     packageName = 'trellis-db'
@@ -66,11 +64,11 @@ buildDeb {
 }
 
 docker {
-    name "trellisldp/trellis-ext-db:${trellisVersion}"
+    name "trellisldp/trellis-ext-db:${project.version}"
     tags 'latest'
     dockerfile file('src/docker/Dockerfile')
-    files tasks.distTar.outputs, 'deployment/src/dist/etc/config.yml','deployment/src/docker/command.sh'
-    buildArgs([BUILD_VERSION: trellisVersion])
+    files tasks.distTar.outputs, './src/dist/etc/config.yml','./src/docker/command.sh'
+    buildArgs([BUILD_VERSION: project.version])
     def gitLabels = ['git.url':'https://github.com/trellis-ldp/trellis-ext-db']
     try {
         git = grgit.open()


### PR DESCRIPTION
This simplifies some of the docker configuration, making it easier to run docker tasks from the root directory. It also changes the version to the version of this project rather than the upstream Trellis version.

@gregjan can you take a look at this? The versioning change will probably affect your test setup -- the new version (based on this PR) would be 0.2.0-SNAPSHOT, rather than 0.8.0-SNAPSHOT, so you may need to remove some of the artifacts from docker hub.