### PR TITLE
changing example config such that it works in a docker environment

### DIFF
--- a/deployment/src/dist/etc/config.yml
+++ b/deployment/src/dist/etc/config.yml
@@ -38,7 +38,7 @@ database:
 
   # The JDBC URL
   # url: jdbc:mysql://db.example.com/db-name
-  url: jdbc:postgresql://db.example.com/db-name
+  url: jdbc:postgresql://db/db-name
 
   properties:
     charSet: UTF-8


### PR DESCRIPTION
Docker swarm does not allow FQDN links between machines, otherwise I could link "db.example.com" to my postgres container.. A simple hostname instead (db) allows me to configure the whole service in swarm with the default configuration.