### PR TITLE
Add no-arg constructors for CDI-managed beans

### DIFF
--- a/db/src/main/java/org/trellisldp/ext/db/DBNamespaceService.java
+++ b/db/src/main/java/org/trellisldp/ext/db/DBNamespaceService.java
@@ -13,6 +13,7 @@
  */
 package org.trellisldp.ext.db;
 
+import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -37,6 +38,15 @@ public class DBNamespaceService implements NamespaceService {
     private static final Logger LOGGER = getLogger(DBNamespaceService.class);
 
     private final Jdbi jdbi;
+
+    /**
+     * Create a namespace service.
+     *
+     * <p>Note: this is generally used for CDI proxies and should not be invoked directly
+     */
+    public DBNamespaceService() {
+        this(Jdbi.create(getConfig().getOptionalValue(DBResourceService.CONFIG_DB_URL, String.class).orElse("")));
+    }
 
     /**
      * Create a namespace service.

--- a/db/src/main/java/org/trellisldp/ext/db/DBResourceService.java
+++ b/db/src/main/java/org/trellisldp/ext/db/DBResourceService.java
@@ -75,6 +75,9 @@ import org.trellisldp.vocabulary.OA;
 @ApplicationScoped
 public class DBResourceService implements ResourceService {
 
+    /** Configuration key used to define a database connection url. */
+    public static final String CONFIG_DB_URL = "trellis.db.url";
+
     /** Configuration key used to define the size of database write batches. */
     public static final String CONFIG_DB_BATCH_SIZE = "trellis.db.batchSize";
     /** The default size of a database batch write operation. */
@@ -90,6 +93,17 @@ public class DBResourceService implements ResourceService {
     private final boolean includeLdpType;
     private final Set<IRI> supportedIxnModels;
     private final int batchSize;
+
+    /**
+     * Create a Database-backed resource service.
+     *
+     * <p>This constructor is generally used by CDI proxies and should
+     * not be invoked directly.
+     */
+    public DBResourceService() {
+        this(Jdbi.create(getConfig().getOptionalValue(CONFIG_DB_URL, String.class).orElse("")),
+                DEFAULT_BATCH_SIZE, false, new DefaultIdentifierService());
+    }
 
     /**
      * Create a Database-backed resource service.

--- a/db/src/test/java/org/trellisldp/ext/db/DBNamespaceServiceTest.java
+++ b/db/src/test/java/org/trellisldp/ext/db/DBNamespaceServiceTest.java
@@ -64,6 +64,24 @@ class DBNamespaceServiceTest {
     }
 
     @Test
+    void testNoargNamespaceService() {
+        try {
+            System.setProperty(DBResourceService.CONFIG_DB_URL, pg.getJdbcUrl("postgres", "postgres"));
+            final NamespaceService svc = new DBNamespaceService();
+
+            assertTrue(svc.getNamespaces().containsKey("ldp"));
+            assertEquals(LDP.getNamespace(), svc.getNamespaces().get("ldp"));
+        } finally {
+            System.clearProperty(DBResourceService.CONFIG_DB_URL);
+        }
+    }
+
+    @Test
+    void testNoargNamespaceServiceNoConfig() {
+        assertDoesNotThrow(() -> new DBNamespaceService());
+    }
+
+    @Test
     void testNamespaceService() {
         final NamespaceService svc = new DBNamespaceService(pg.getPostgresDatabase());
 

--- a/db/src/test/java/org/trellisldp/ext/db/DBResourceTest.java
+++ b/db/src/test/java/org/trellisldp/ext/db/DBResourceTest.java
@@ -113,6 +113,25 @@ class DBResourceTest {
     }
 
     @Test
+    void testNoargResourceService() {
+        try {
+            System.setProperty(DBResourceService.CONFIG_DB_URL, pg.getJdbcUrl("postgres", "postgres"));
+            final ResourceService svc2 = new DBResourceService();
+            svc2.get(root).thenAccept(res -> {
+                assertEquals(LDP.BasicContainer, res.getInteractionModel());
+                assertFalse(res.getContainer().isPresent());
+            }).toCompletableFuture().join();
+        } finally {
+            System.clearProperty(DBResourceService.CONFIG_DB_URL);
+        }
+    }
+
+    @Test
+    void testNoargResourceServiceNoConfig() {
+        assertDoesNotThrow(() -> new DBResourceService());
+    }
+
+    @Test
     void getRoot() {
         assertEquals(root, DBResource.findResource(pg.getPostgresDatabase(), root, false)
                 .toCompletableFuture().join().getIdentifier(), "Check the root resource");


### PR DESCRIPTION
Related to trellis-ldp/trellis#537

This adds no-arg constructors to the various managed beans for better
re-use in downstream applications such as quarkus.